### PR TITLE
Add support for custom sample rates

### DIFF
--- a/lib/membrane_aac_format/aac.ex
+++ b/lib/membrane_aac_format/aac.ex
@@ -115,14 +115,14 @@ defmodule Membrane.AAC do
   @spec profile_to_aot_id(profile_t) :: audio_object_type_id_t
   def profile_to_aot_id(profile), do: BiMap.fetch_key!(audio_object_type(), profile)
 
-  @spec sampling_frequency_id_to_sample_rate(sampling_frequency_id_t) :: pos_integer
+  @spec sampling_frequency_id_to_sample_rate(sampling_frequency_id_t) :: pos_integer | :explicit
   def sampling_frequency_id_to_sample_rate(sampling_frequency_id),
     do: BiMap.fetch!(sampling_frequency(), sampling_frequency_id)
 
-  @spec sample_rate_to_sampling_frequency_id(sample_rate :: pos_integer | :explicit) ::
+  @spec sample_rate_to_sampling_frequency_id(sample_rate :: pos_integer) ::
           sampling_frequency_id_t
   def sample_rate_to_sampling_frequency_id(sample_rate),
-    do: BiMap.fetch_key!(sampling_frequency(), sample_rate)
+    do: BiMap.get_key(sampling_frequency(), sample_rate, 15)
 
   @spec channel_config_id_to_channels(channel_config_id_t) :: pos_integer | :AOT_specific
   def channel_config_id_to_channels(channel_config_id),


### PR DESCRIPTION
- Return `frequency_id` 15 when trying to get frequency id for custom sample rate